### PR TITLE
Problem: travis install script is out of date

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -42,4 +42,4 @@ else
   popd
 fi
 
-cd pulp-swagger-codegen
+cd pulp-openapi-generator


### PR DESCRIPTION
Solution: update the install

The change of the repository name to pulp-openapi-generator required updating the
travis install script.

[noissue]