### PR TITLE
Problem: ruby client is generated with encoded URL

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -30,7 +30,7 @@ then
 fi
 if [ $2 = 'ruby' ]
 then
-    docker run -u $(id -u) --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
+    docker run -u $(id -u) --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v4.0.0 generate \
         -i /local/api.json \
         -g ruby \
         -o /local/$1-client \


### PR DESCRIPTION
Solution: ping version of openapi-generator-cli to v4.0.0

This version of openapi-generator does not have the patch that causes the encoding of the
URL.

fixes: #4904
https://pulp.plan.io/issues/4904