### PR TITLE
Problem: ruby client can't form-encode PUT requests

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -18,7 +18,8 @@ if [ -n "$PULP_PR_NUMBER" ]; then
 fi
 
 pip install -e ./pulpcore[postgres]
-cp ./pulpcore/.travis/test_bindings.py $TRAVIS_BUILD_DIR/
+cp ./pulpcore/.travis/test_bindings.py $TRAVIS_BUILD_DIR/.travis/
+cp ./pulpcore/.travis/test_bindings.rb $TRAVIS_BUILD_DIR/.travis/
 
 git clone https://github.com/pulp/pulpcore-plugin.git
 

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -18,13 +18,26 @@ rq worker -n 'reserved-resource-worker_1@%h' -w 'pulpcore.tasking.worker.PulpWor
 sleep 8
 
 sudo ./generate.sh pulpcore python
-
 sudo ./generate.sh pulp_file python
-
 pip install ./pulpcore-client
 pip install ./pulp_file-client
 
-python test_bindings.py
+python .travis/test_bindings.py
+
+sudo rm -rf ./pulpcore-client
+sudo rm -rf ./pulp_file-client
+
+./generate.sh pulpcore ruby
+cd pulpcore-client
+gem build pulpcore_client
+gem install --both ./pulpcore_client-0.gem
+cd ..
+./generate.sh pulp_file ruby
+cd pulp_file-client
+gem build pulp_file_client
+gem install --both ./pulp_file_client-0.gem
+cd ..
+ruby .travis/test_bindings.rb
 
 # Travis' scripts use unbound variables. This is problematic, because the
 # changes made to this script's environment appear to persist when Travis'

--- a/generate.sh
+++ b/generate.sh
@@ -30,13 +30,18 @@ then
 fi
 if [ $2 = 'ruby' ]
 then
-    docker run -u $(id -u) --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v4.0.0 generate \
-        -i /local/api.json \
+    if [ ! -f ./openapi-generator-cli.jar ]
+    then
+        curl -o openapi-generator-cli.jar https://repos.fedorapeople.org/pulp/pulp/openapi/openapi-generator-cli.jar
+    fi
+    java -jar openapi-generator-cli.jar generate \
+        -i api.json \
         -g ruby \
-        -o /local/$1-client \
+        -o $1-client \
         -DgemName=$1_client \
-        -DgemLicense="GPLv2" \
+        -DgemLicense="GPL-2.0" \
         -DgemVersion=${VERSION} \
+        -Dlibrary=faraday \
         --skip-validate-spec \
         --strict-spec=false
 fi


### PR DESCRIPTION
Solution: switch ruby client to use Faraday

This patch relies on a forked version of the openapi-generator-cli. Once the PR that
introduces this functionality is merged into openapi-generator, the ruby client
generation should be switched back to using the docker container for openapi-generator.

https://github.com/OpenAPITools/openapi-generator/pull/3405

Required PR: https://github.com/pulp/pulpcore/pull/226

re: #4896
https://pulp.plan.io/issues/4896