### PR TITLE
Add a Python3-only restriction to the generated client bindings

### DIFF
--- a/templates/python/setup.mustache
+++ b/templates/python/setup.mustache
@@ -1,0 +1,45 @@
+# coding: utf-8
+
+{{>partial_header}}
+
+from setuptools import setup, find_packages  # noqa: H301
+
+NAME = "{{{projectName}}}"
+VERSION = "{{packageVersion}}"
+{{#apiInfo}}
+{{#apis}}
+{{^hasMore}}
+# To install the library, run the following
+#
+# python setup.py install
+#
+# prerequisite: setuptools
+# http://pypi.python.org/pypi/setuptools
+
+REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+{{#asyncio}}
+REQUIRES.append("aiohttp >= 3.0.0")
+{{/asyncio}}
+{{#tornado}}
+REQUIRES.append("tornado>=4.2,<5")
+{{/tornado}}
+setup(
+    name=NAME,
+    version=VERSION,
+    description="{{appName}}",
+    author="{{#infoName}}{{infoName}}{{/infoName}}{{^infoName}}Pulp Team{{/infoName}}",
+    author_email="{{#infoEmail}}{{infoEmail}}{{/infoEmail}}{{^infoEmail}}pulp-list@redhat.com{{/infoEmail}}",
+    url="{{packageUrl}}",
+    keywords=["pulp", "pulpcore", "client", "{{{appName}}}"],
+    install_requires=REQUIRES,
+    python_requires='>=3.4',  # restrict client usage to Python 3 only
+    packages=find_packages(exclude=["test", "tests"]),
+    include_package_data=True,
+    {{#licenseInfo}}license="{{licenseInfo}}",
+    {{/licenseInfo}}long_description="""\
+    {{appDescription}}  # noqa: E501
+    """
+)
+{{/hasMore}}
+{{/apis}}
+{{/apiInfo}}


### PR DESCRIPTION
closes: #7110
https://pulp.plan.io/issues/7110