### PR TITLE
Set the homepage in generated gems

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -73,7 +73,7 @@ then
         -i /local/api.json \
         -g ruby \
         -o /local/$1-client \
-        --additional-properties=gemName=$1_client,gemLicense="GPL-2.0+",gemVersion=${VERSION} \
+        --additional-properties=gemName=$1_client,gemLicense="GPL-2.0+",gemVersion=${VERSION},gemHomepage=https://github.com/pulp/$1 \
         --library=faraday \
         -t /local/templates/ruby \
         --skip-validate-spec \


### PR DESCRIPTION
This sets the homepage for gems (per [docs](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/ruby.md#config-options)), rather than the default https://openapi-generator.tech/ which is unhelpful. It chooses the specific gem rather than the URL of the generator config.

[noissue]