### PR TITLE
Add a shebang to generate and exit immediately on failure

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -e
+
 if [ $# -eq 0 ]; then
     echo "No arguments provided"
     exit 1


### PR DESCRIPTION
bash -e exits immediately if a command fails. This means it doesn't try to run commands in an invalid state. AFAIK this is a bashism so the bash shebang is added.

If the command runs as `sh generate.sh` it does not use the -e mode and it'll remain POSIX compatible.