### PR TITLE
Raise Faraday compatibility to < 2.0

### DIFF
--- a/templates/ruby/api_client_faraday_partial.mustache
+++ b/templates/ruby/api_client_faraday_partial.mustache
@@ -111,7 +111,7 @@
           case value
           when ::File, ::Tempfile
             # TODO hardcode to application/octet-stream, need better way to detect content type
-            data[key] = Faraday::UploadIO.new(value.path, 'application/octet-stream', value.path)
+            data[key] = Faraday::FilePart.new(value.path, 'application/octet-stream', value.path)
           when ::Array, nil
             # let Faraday handle Array and nil parameters
             data[key] = value

--- a/templates/ruby/gemspec.mustache
+++ b/templates/ruby/gemspec.mustache
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"
 
   {{#isFaraday}}
-  s.add_runtime_dependency 'faraday', '>= 0.17', '< 1.9.0'
+  s.add_runtime_dependency 'faraday', '>= 0.17', '< 1.9'
   {{/isFaraday}}
   {{^isFaraday}}
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'

--- a/templates/ruby/gemspec.mustache
+++ b/templates/ruby/gemspec.mustache
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"
 
   {{#isFaraday}}
-  s.add_runtime_dependency 'faraday', '>= 0.17', '< 1.9'
+  s.add_runtime_dependency 'faraday', '>= 0.17', '< 2.0'
   {{/isFaraday}}
   {{^isFaraday}}
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'


### PR DESCRIPTION
I'd still need to verify this works. https://github.com/OpenAPITools/openapi-generator/pull/13127 is the upstream version of replacing `Faraday::UploadIO`.