### PR TITLE
Require at least Faraday 1.0

### DIFF
--- a/templates/ruby/gemspec.mustache
+++ b/templates/ruby/gemspec.mustache
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"
 
   {{#isFaraday}}
-  s.add_runtime_dependency 'faraday', '>= 0.17', '< 2.0'
+  s.add_runtime_dependency 'faraday', '>= 1.0.1', '< 2.0'
   {{/isFaraday}}
   {{^isFaraday}}
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'


### PR DESCRIPTION
In 41693f8a1038375456015652fd299254b9ce817d UploadIO was replaced by FilePart. I kept the lower bound on 0.17 since I checked to commit that aliases the two was in v0.16.0:

```console
$ git tag --contains 249835f8b6a6a76a48e945d27393d0a5f91b64ea | head -n 5
v0.16.0
v0.16.1
v0.16.2
v1.0.0
v1.0.1
```

Now the careful reader (which I wasn't) will notice 0.17.x isn't in there. That is because the Faraday 0.17 branch was based on 0.15.4 and rolled back all changes in 0.16.x.

This raises the minimum version to 1.0.1 which matches openapi-generator's lower bound.

Thanks to @zjhuntin for reporting this.

Fixes: 41693f8a1038375456015652fd299254b9ce817d