### PR TITLE
Use oci-env's environment variable to define the default container engine

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -5,7 +5,28 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-if command -v podman > /dev/null
+
+get_container_engine () {
+
+    # allow override from callers such as oci-env
+    if [ -z ${COMPOSE_BINARY} ]; then
+        echo "${COMPOSE_BINARY}"
+        return
+    fi
+
+    # use podman if found
+    if command -v podman > /dev/null; then
+        echo "podman"
+        return
+    fi
+
+    # default to docker
+    echo "docker"
+}
+
+
+container_engine=$(get_container_engine)
+if [[ "${container_engine}" == "podman" ]]
 then
   container_exec=podman
   ULIMIT_COMMAND=


### PR DESCRIPTION
oci-env sets an COMPOSE_BINARY environment variable for all subprocesses based on the user's config. That will now influnce the build.sh script in this repo to use whatever the user has configured instead of defaulting to podman if found in the path.