### PR TITLE
Add support for Docker in Docker and local openapi schema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,15 @@ If you want to use a locally present openapi schema, you can skip fetching the o
 by setting the ``USE_LOCAL_API_JSON`` environment variable. Doing so you have to manually provide the
 ``api.json`` file containing the openapi schema in the current working directory.
 
+Generate Bindings Using Docker in Docker (dind)
+-----------------------------------------------
+
+Bindings are generated using the openapi-generator-cli docker container. If your environment itself runs in
+a docker container, the openapi-generator-cli container has to be started as a sibling container. For
+sibling containers, volumes cannot be mounted as usual. They have to be passed through from the parent
+container. For this to work you have to set the ``PARENT_CONRAINER_ID`` environment variable to specify the
+parent container in a dind environment.
+
 Generating Bindings on a Filesystem Shared With Another Container
 -----------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,15 @@ variable to instruct the bindings generator where the root of the API is located
 default ``export PULP_API_ROOT="/pulp/"`` is the default root, which then serves the api.json at
 ``/pulp/api/v3/docs/api.json``.
 
+Generating Bindings Against Remote Systems
+------------------------------------------
+
+During bindings generation the openapi schema is fetched. Use the ``PULP_API`` environment
+variable to instruct the bindings generator to use a Pulp API on a different host and/or port.
+For example, ``export PULP_API="http://localhost:24817"`` are the default host and port, which
+results in the bindings generator talking to the Pulp API at
+``http://localhost:24817/pulp/api/v3/docs/api.json``.
+
 Generating Bindings on a Filesystem Shared With Another Container
 -----------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,13 @@ For example, ``export PULP_API="http://localhost:24817"`` are the default host a
 results in the bindings generator talking to the Pulp API at
 ``http://localhost:24817/pulp/api/v3/docs/api.json``.
 
+Generating Bindings Using a Local Openapi Schema
+-----------------------------------------------
+
+If you want to use a locally present openapi schema, you can skip fetching the openapi schema
+by setting the ``USE_LOCAL_API_JSON`` environment variable. Doing so you have to manually provide the
+``api.json`` file containing the openapi schema in the current working directory.
+
 Generating Bindings on a Filesystem Shared With Another Container
 -----------------------------------------------------------------
 

--- a/generate.sh
+++ b/generate.sh
@@ -38,15 +38,20 @@ else
   volume_name="/local"
 fi
 
-PULP_URL="${PULP_URL:-http://localhost:24817}"
+# Skip downloading the api.json if `USE_LOCAL_API_JSON` is set.
+if [[ -z $USE_LOCAL_API_JSON ]]
+then
+  PULP_URL="${PULP_URL:-http://localhost:24817}"
 
-PULP_API_ROOT="${PULP_API_ROOT:-/pulp/}"
+  PULP_API_ROOT="${PULP_API_ROOT:-/pulp/}"
 
-PULP_URL="${PULP_URL}${PULP_API_ROOT}api/v3/"
+  PULP_URL="${PULP_URL}${PULP_API_ROOT}api/v3/"
 
-# Download the schema
-curl -k -o api.json "${PULP_URL}docs/api.json?bindings&plugin=$1"
-# Get the version of the pulpcore or plugin as reported by status API
+  # Download the schema
+  curl -k -o api.json "${PULP_URL}docs/api.json?bindings&plugin=$1"
+  # Get the version of the pulpcore or plugin as reported by status API
+fi
+
 export DOMAIN_ENABLED=$(jq -r '.info | ."x-pulp-domain-enabled" // false' < api.json)
 
 if [ $# -gt 2 ];


### PR DESCRIPTION
Our build pipeline is running in a Docker environment. Also the openapi schema is fetched in a previous stage and passed on to the next stage for generating the client bindings.
This makes two adjustments necessary I want to introduce with this PR:

- Currently in the `generate.sh` script the client bindings are fetched from an running Pulp API. A new variable `USE_LOCAL_API_JSON` is introduced. If this variable is set, the script assumes that the openapi schema is already present in the working directory. If the variable is unset, the behavior of the script does not change.
- When spawning up the `openapi-generator-cli` container the current working directory is mounted. If we run the `generate.sh` script inside a docker container we have to mount the working directory on the parent container and pass it to the sibling container (i.e. the `openapi-generator-cli` container) with the `--volumes-from` option. A new variable `PARENT_CONTAINER_ID` is introduced.  If this variable is set, the volumes mounted for the `openapi-generator-cli` container are mounted using the `--volumes-from` option. If the variable is unset, the behavior of the script does not change.

Besides that the first commit adds a section to the Readme about the usage of the `PULP_API` variable.