### PR TITLE
Authenticate for pulp status call and use explicit GET

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -67,7 +67,7 @@ else
         COMPONENT_NAME=${1#"pulp_"}
     fi
 
-    VERSION=$(http ${PULP_URL}status/ | jq --arg plugin $COMPONENT_NAME -r '.versions[] | select(.component == $plugin) | .version')
+    VERSION=$(http --auth admin:password GET ${PULP_URL}status/ | jq --arg plugin $COMPONENT_NAME -r '.versions[] | select(.component == $plugin) | .version')
     export VERSION
 fi
 


### PR DESCRIPTION
when running the generate.sh script with oci-env the calls to  `${PULP_URL}status/` did not work anymore for me.

Probably this error was previously masked by https://github.com/pulp/pulp-openapi-generator/commit/5c8eddcae77bdc825738600e70e8be2405140cf8 

`export VERSION=$(failing command)`

vs.

```
VERSION=$(failing command)
export VERSION
````