### PR TITLE
Support older bash versions

### DIFF
--- a/gen-client.sh
+++ b/gen-client.sh
@@ -54,7 +54,7 @@ DOMAIN_ENABLED="$(jq -r '.info."x-pulp-domain-enabled" // false' < "${API_SPEC}"
 VERSION="$(jq -r --arg component "${COMPONENT}" '.info."x-pulp-app-versions"[$component] // error("No version found.")' < "${API_SPEC}" | normalize_version)"
 CORE_VERSION="$(jq -r '.info."x-pulp-app-versions".core // "0.0.0"' < "${API_SPEC}" | normalize_version)"
 GENERATOR_VERSION="$(generator_version "${LANGUAGE}" <<<"${CORE_VERSION}")"
-IMAGE_OVERRIDE_VAR="OPENAPI_${LANGUAGE^^}_IMAGE"
+IMAGE_OVERRIDE_VAR="OPENAPI_$(echo "${LANGUAGE}" | tr '[:lower:]' '[:upper:]')_IMAGE"
 OPENAPI_IMAGE="${!IMAGE_OVERRIDE_VAR:-docker.io/openapitools/openapi-generator-cli:${GENERATOR_VERSION}}"
 IMAGE_TAG="${OPENAPI_IMAGE#*:}"
 


### PR DESCRIPTION
Looks like the `^^` parameter expansion is not supported in earlier versions of bash, resulting in a failure when running the `generate-client` command.

```shell
harish at busybox in ~/Workspaces/oss/pulp/oci_env on setup/osx
(pulpcore) ± bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin24)
Copyright (C) 2007 Free Software Foundation, Inc.

harish at busybox in ~/Workspaces/oss/pulp/oci_env on setup/osx
(pulpcore) ± oci-env generate-client -i
2025-01-19 22:39:17,260 - INFO - utils.py:17 - USING OCI_ENV_PATH FROM ENV: /Users/harish/Workspaces/oss/pulp/oci_env
2025-01-19 22:39:17,260 - INFO - utils.py:17 - USING OCI_ENV_PATH FROM ENV: /Users/harish/Workspaces/oss/pulp/oci_env
2025-01-19 22:39:17,260 - INFO - utils.py:17 - USING OCI_ENV_PATH FROM ENV: /Users/harish/Workspaces/oss/pulp/oci_env
Generating python-client for pulpcore.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1017k  100 1017k    0     0  2007k      0 --:--:-- --:--:-- --:--:-- 2006k
::group::BINDINGS
./gen-client.sh: line 57: OPENAPI_${LANGUAGE^^}_IMAGE: bad substitution
```