### PR TITLE
[PULP-398] Update docs on bindings generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ target/
 .ipynb_checkpoints
 
 # generated stuff
-/api.json
-/patched-api.json
+/*api.json
 /*-client/
 .openapi-generator-ignore

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# Welcome to Pulp OpenAPI-Generator
+
+This repository provides a script and a base setup to help generate different language bindings for pulpcore or any of it's plugins.
+
+- [Get started quickly](site:pulp-openapi-generator/docs/user/guides/generate-bindings/).
+- [Learn how it works](site:pulp-openapi-generator/docs/user/learn/how-it-works/)

--- a/docs/user/guides/version-migrations.md
+++ b/docs/user/guides/version-migrations.md
@@ -1,0 +1,29 @@
+# Version Migrations
+
+The [openapi-generator-cli image] version used depends on the pulpcore version.
+
+This guide list known breaking changes and recommended compatibility actions for pulpcore upgrade paths.
+
+## pulpcore `<3.70` to `>=3.70`
+
+Upgrading pulpcore from a `<3.70` to a `>=3.70` version will bump the `openapi-generator-cli` version from `4.3.1` to `7.10.0`.
+
+### Python
+
+- `Response.to_dict()|.to_json()` returns a dictionary without read-only fields.
+    - **Example**: `pulp_href` isn't present anymore.
+    - **Actions**: Use `Response.model_dump()`. See [model_dump docs].
+- Client-side validation is more strict.
+    - **Example**: Error handling depending on server-errors might break.
+    - **Actions**: Update code to use client-side errors.
+- Clients now use named arguments instead of positional ones
+    - **Action**: Use named arguments.
+- Object such as Path or UUID are not accepted as input
+    - **Action**: Cast to string. E.g `str(uuid)` and `str(path)`.
+
+### Ruby
+
+Unknown.
+
+[model_dump docs]: https://docs.pydantic.dev/2.10/concepts/serialization/#modelmodel_dump
+[openapi-generator-cli image]: https://hub.docker.com/r/openapitools/openapi-generator-cli

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -1,9 +1,0 @@
-# Overview
-
-This repository provides a script that helps generate Python and Ruby bindings for pulpcore or any of it's
-plugins.
-
-The first time the script is run, a docker container with openapi-generator-cli is downloaded. All
-subsequent runs will re-use the container that was downloaded on the initial run.
-
-

--- a/docs/user/learn/how-it-works.md
+++ b/docs/user/learn/how-it-works.md
@@ -1,0 +1,37 @@
+# How it works
+
+Pulp OpenAPI Generator builds upon the [OpenAPI Generator CLI] to provide client bindings tailored for Pulp's API.
+Here's what it does on top of it.
+
+## Template Overrides
+
+The generator uses Mustache templates that override the standard [OpenAPI Generator templates].
+These templates are used for the language-specific code generation.
+They are organized by language and version in the `templates/` directory.
+
+For example, `templates/ruby/7.10.0/gemspec.mustache` will override the [original file with the same name] in the openapi-generator repository for that version.
+
+To avoid getting too much into the generator internals, we try to use it only when absolutely required.
+
+## Custom Parameters
+
+The Pulp generator script reads Pulp specific fields from the `api.spec` (such as Domain enabled)
+and passes specific parameters to [configure the OpenAPI Generator CLI].
+E.g, set namings, define appropriate version information, set domains and configure flags that make the client more stable.
+
+For this to work, the `api.spec` needs to be generated with the `--bindings` option/url-parameter as shown in the [generate-bindings guide],
+which results in a not fully compliant api spec.
+
+## Version Management
+
+Pulp supports multiple branches of pulpcore, and it uses python bindings in all the CI functional tests.
+To keep everything working and being able to upgrade the generator cli version, we have a pinning mechanism in place to couple pulpcore with the generator version.
+
+This versioning system is documented in the [version-migrations guide].
+
+[configure the openapi generator cli]: https://openapi-generator.tech/docs/configuration
+[generate-bindings guide]: site:pulp-openapi-generator/docs/user/guides/generate-bindings/#2-get-the-schema
+[openapi generator cli]: https://openapi-generator.tech/docs/installation#docker
+[openapi generator templates]: https://openapi-generator.tech/docs/templating
+[original file with the same name]: https://github.com/OpenAPITools/openapi-generator/blob/v7.10.0/modules/openapi-generator/src/main/resources/ruby-client/gemspec.mustache
+[version-migrations guide]: site:pulp-openapi-generator/docs/user/guides/version-migrations/

--- a/docs/user/reference/settings.md
+++ b/docs/user/reference/settings.md
@@ -1,0 +1,21 @@
+# Settings
+
+## `PARENT_CONTAINER_ID`
+
+**For Docker-in-Docker (dind) environments**.
+Specify the parent container.
+
+Bindings are generated using the openapi-generator-cli docker container.
+If your environment itself runs in a docker container, the openapi-generator-cli container has to be started as a sibling container.
+For sibling containers, volumes cannot be mounted as usual.
+They have to be passed through from the parent container.
+
+## `PULP_MCS_LABEL`
+
+**For filesystem shared with another container**.
+Set MCS (Multi-Category Security) labels to generator container (e.g. `s0:c1,c2`).
+
+When the bindings are being generated so that they can be installed inside another container,
+it may be necessary to set the MCS label on the openapi-generator-cli container to match the MCS label of the other container.
+When this variable is present, the container for `openapi-generator-cli` will be started with this MCS label.
+This only applies to systems that are using `podman` and SELinux is `Enforcing`.

--- a/gen-client.sh
+++ b/gen-client.sh
@@ -2,10 +2,41 @@
 
 set -eu
 
+SCRIPT_NAME="$(basename "$0")"
+
 if [ $# -eq 0 ]
 then
-  echo "No arguments provided"
-  echo "Usage: $0 <api_spec> <component> [<language> [<package>]]"
+  cat << EOF
+No arguments provided.
+${SCRIPT_NAME} - Generate client libraries for pulp plugins.
+
+USAGE
+    ${SCRIPT_NAME} <api_spec> <component> [<language> [<package>]]
+
+ARGS
+    api_spec:  The openapi schema file in json format.
+    component: The pulp component target client. It should be a key in the
+               'info.x-pulp-app-versions' object from the <api_spec> file.
+    language:  The target language for the client generation. Default: python.
+    package:   The name of the generated package name in the target language.
+               Default: pulp_{component}
+
+DESCRIPTION
+    Generate a client for the given <language> and Pulp <component> using the
+    provided openapi <api_spec>.
+
+    The package will be created at './<package>-client/'.
+
+    Learn more:
+    <https://pulpproject.org/pulp-openapi-generator/docs/user/guides/generate-bindings/>
+
+EXAMPLES
+    Generate a pulp_rpm ruby client at 'pulp_rpm-client/' using 'rpm-api.json' spec:
+    $ ${SCRIPT_NAME} rpm-api.json rpm ruby
+
+    Generate a pulp_maven python client at 'my-maven-client/' using 'maven-api.json' spec:
+    $ ${SCRIPT_NAME} maven-api.json maven python my-maven
+EOF
   exit 1
 fi
 

--- a/generate.sh
+++ b/generate.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+echo "DEPRECATED: use ./gen-client.sh instead."
+
 if [ $# -eq 0 ]
 then
   echo "No arguments provided"
@@ -39,7 +41,7 @@ fi
 
 echo ::group::BINDINGS
 
-./gen-client.sh api.json "${COMPONENT}" "${2:-python}" "${1}"
+./gen-client.sh "${USE_LOCAL_API_JSON:-api.json}" "${COMPONENT}" "${2:-python}" "${1}"
 
 echo ::endgroup::
 if [[ -z "${USE_LOCAL_API_JSON:-}" ]]


### PR DESCRIPTION
This PR does:
1. Create pages for index, internal working, settings and version migration guides.
2. Update page on binding generation
3. Update main script `gen-client.sh` help text
4. Update `generate.sh` to output a deprecate message on any execution

Closes https://github.com/pulp/pulpcore/issues/6263

---

Btw, I'm running with:

```
pulp-docs serve --no-blog --draft --no-docstrings --path pulp-openapi-generator@..
```